### PR TITLE
Fix losetup error

### DIFF
--- a/run
+++ b/run
@@ -522,6 +522,11 @@ run_mkdrive() {
             local targetvol=(-v "$targetdir:$targetdir")
         fi
         docker run --rm                               \
+                   -v /lib/modules:/lib/modules       \
+                   --privileged                       \
+                   "$DOCKER_IMAGE"                    \
+                   modprobe loop
+        docker run --rm                               \
                    ${targetvol[@]}                    \
                    -v "$CURDIR":/ktest                \
                    -v "$USR_CACHE_DIR:$USR_CACHE_DIR" \


### PR DESCRIPTION
Fix losetup error: failed to set up loop device: No such file or directory
when ktest first running on client