### PR TITLE
Add bc utility as a dependency

### DIFF
--- a/run
+++ b/run
@@ -15,7 +15,7 @@
 #
 set -e
 export LANG=C
-DEPS=(socat xml virsh)
+DEPS=(socat xml virsh bc)
 
 : ${CONFIG:=.ktest}
 if [ -z "$NO_CONFIG" ] && [ -f $CONFIG ]; then


### PR DESCRIPTION
        Not all docker containers has bc utility as default
        It is necessary to check the availability of the bc before starting