### PR TITLE
Replace which with command -v

### DIFF
--- a/mkinitrd
+++ b/mkinitrd
@@ -106,7 +106,7 @@ entrypoint="$GUEST/profile"
 check_progs() {
     local notfound=0
     for prog in "$@"; do
-        if ! which "$prog" 2>/dev/null 1>&2; then
+        if ! command -v "$prog" 2>/dev/null 1>&2; then
             echo "ERROR: Can't find \"$prog\" in \$PATH"
             ((notfound++))
         fi

--- a/run
+++ b/run
@@ -292,7 +292,7 @@ parse_options(){
     CRASH_VOLUME="crashes-$OWNER"
 
     for dep in "${DEPS[@]}"; do
-        which $dep &>/dev/null || die "$dep is not installed"
+        command -v $dep &>/dev/null || die "$dep is not installed"
     done
 }
 

--- a/tests/Dockerfile.opensuse
+++ b/tests/Dockerfile.opensuse
@@ -3,7 +3,6 @@ FROM $SUSE_IMAGE
 RUN zypper -n install kernel-default \
                       kexec-tools    \
                       makedumpfile   \
-                      which          \
                       openssh        \
                       tar            \
                       kmod-compat    \


### PR DESCRIPTION
Replace all occurrences of using `which` tool with bash `command -v` built-in.
This gets rid of `which` tool dependency which is not always installed by default in base containers.

Closes #2