### PR TITLE
Add a way to collect-crash logs for large dmesg and core dump

### DIFF
--- a/guest/collect-crash
+++ b/guest/collect-crash
@@ -25,13 +25,13 @@ if [ "$crashdrive" != "" ]; then
     echo "ktest: mount crashdrive $uuid at $mount_point" > /dev/kmsg
     mount -t $fs -U $uuid $mount_point
 
-    core_dst="$mount_point/crash.dump"
-    echo "ktest: save crash to $core_dst" > /dev/kmsg
-    makedumpfile -c -d 31 /proc/vmcore "$core_dst"
-
     dmesg_dst="$mount_point/dmesg.gz"
     echo "ktest: save dmesg to $dmesg_dst" > /dev/kmsg
-    vmcore-dmesg /proc/vmcore | gzip -c > "$dmesg_dst"
+    makedumpfile -c --dump-dmesg --num-threads $(nproc) /proc/vmcore "$dmesg_dst"
+
+    core_dst="$mount_point/crash.dump"
+    echo "ktest: save crash to $core_dst" > /dev/kmsg
+    makedumpfile -c -d 31 --num-threads $(nproc) /proc/vmcore "$core_dst"
 
     VP_CLASS=/sys/class/virtio-ports
     CHANNEL_NAME="org.ktest.channel.0"

--- a/guest/profile
+++ b/guest/profile
@@ -3,11 +3,11 @@ if grep -q "crashkernel=\S\+" < /proc/cmdline; then
     echo "ktest: Setting up kdump" > /dev/kmsg
     case `uname -m` in
         x86_64)
-            CMDLINE="console=ttyS0 maxcpus=1 reset_devices"
+            CMDLINE="console=ttyS0 maxcpus=$(nproc) reset_devices"
             KEXEC_OPTS="--console-serial"
             ;;
         ppc64le)
-            CMDLINE="console=hvc0 maxcpus=1 noirqdistrib reset_devices"
+            CMDLINE="console=hvc0 maxcpus=$(nproc) noirqdistrib reset_devices"
             ;;
         *)
             ;;

--- a/mkinitrd
+++ b/mkinitrd
@@ -155,7 +155,7 @@ if [ -n "$KDUMP" ]; then
     mkdir -p "$bootdir"
     kernel=$(find /boot -name 'vmlinu[x|z]')
     cp "$kernel" "$bootdir"
-    KDUMP_INSTALL=(gzip vmcore-dmesg makedumpfile scp grep cut tar)
+    KDUMP_INSTALL=(gzip nproc makedumpfile scp grep cut tar)
 
     check_progs "${KDUMP_INSTALL[@]}"
     dracut -N --force                                                         \

--- a/run
+++ b/run
@@ -46,6 +46,7 @@ N_CHANNEL_PORTS=999
 : ${VM_TIMEOUT:=600}
 : ${VCPU:=1}
 : ${KDUMP_TIMEOUT:=180}
+: ${CRASHDRIVE_SIZE:=5G}
 declare -a DISKNAMES
 declare -a KOPT
 declare -a MKINITRD_ARGS
@@ -127,6 +128,16 @@ options:
     --kdump-timeout TIMEOUT        Specifies time limit for kernel dump.
                                    A VM is shut down if it doesn't manage to
                                    save kdump within the time limit.
+    --crashdrive-size SIZE         Is the crash drive SIZE in bytes.
+                                   Optional suffixes:
+                                   'k' or 'K' (kilobyte, 1024),
+                                   'M' (megabyte, 1024k),
+                                   'G' (gigabyte, 1024M),
+                                   'T' (terabyte, 1024G),
+                                   'P' (petabyte, 1024T),
+                                   'E' (exabyte, 1024P)
+                                   'b' is ignored
+                                   5G by default.
 EOF
 }
 
@@ -234,6 +245,9 @@ parse_options(){
             shift 2
         elif [ "$1" == "--kdump-timeout" ]; then
             KDUMP_TIMEOUT="$2"
+            shift 2
+        elif [ "$1" == "--crashdrive-size" ]; then
+            CRASHDRIVE_SIZE="$2"
             shift 2
         else
             POSITIONAL+=("$1")
@@ -615,7 +629,7 @@ VOLUMES+=("$INITRAMFS_VOLUME:$INITRAMFS:raw:")
 
 CRASHDRIVE="$USR_CACHE_DIR/$VMNAME/crash.qcow2"
 CRASHDRIVE_UUID=$(drive_uuid "$USR_CACHE_DIR/$VMNAME/crash.uuid")
-run_mkdrive "$CRASHDRIVE" 5G xfs $CRASHDRIVE_UUID
+run_mkdrive "$CRASHDRIVE" "$CRASHDRIVE_SIZE" xfs $CRASHDRIVE_UUID
 VOLUMES+=("$CRASH_VOLUME:$CRASHDRIVE:qcow2:blk")
 KOPT+=("ktest.crashdrive=$CRASHDRIVE_UUID:xfs:/crashes")
 


### PR DESCRIPTION
    Add a way to change the crash drive system size.
    Change Vmcore-dmesg to makedumpfile.
    Makedumpfile use multiple threads to read and compress data of each page in parallel (Chang maxcpus to number of processors in VM).